### PR TITLE
JSON.parse may fail and needs to be wrapped

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,15 +10,17 @@ module.exports.getToken = function (params, cb) {
             "assertion": jwt.token
         } },
         function (error, response, body) {
-            if (!error){
-                if(response.statusCode === 200) {
-                    return cb(null, JSON.parse(body));
-                } else {
-                    return cb(JSON.parse(body),null);
+            try {
+                if (!error) {
+                    if (response.statusCode === 200) {
+                        return cb(null, JSON.parse(body));
                 }
-            } else {
-                return cb(error,null);
+                return cb(JSON.parse(body), null);
+              }
+            } catch (err) {
+                cb(err, null);
             }
-        }
+            return cb(error, null);
+    }
     );
 }


### PR DESCRIPTION
part of changing done in salesforce we had our production servers down because this package failed. 
```
JSON.parse(body)
```
was failing and it become uncaught and crashed our servers.